### PR TITLE
Change in Klipper macro naming convention and bugfix for UndefinedError in LOW_TEMP_CHECK

### DIFF
--- a/ADVANCED_PAUSE.cfg
+++ b/ADVANCED_PAUSE.cfg
@@ -8,6 +8,9 @@
 #  NO RESPONSE TAKEN FOR ANY DAMAGE CAUSED BY MOM ;)
 #------------------------------------------------------
 #
+# 01/14/2025 v9.4.2
+# Changed gcode macro name from 'm600cfg' to 'cfg_m600' because of naming convention change. Macro's not conforming to this convention cannot be registered in Klipper.
+#
 # 04/30/2022 v0.4.1
 # Corrected bugs with M125 and raising the zmin twice.
 #
@@ -24,7 +27,7 @@
 # Corrected bug for fans variable overwriting the cool variable.
 #
 # 04/26/2022 v0.3.2
-# Removed call for variable in HTML UI and added a missing variable for Z_feedrate in m600cfg.
+# Removed call for variable in HTML UI and added a missing variable for Z_feedrate in cfg_m600.
 #
 # 04/26/2022 v0.3.1
 # Corrected variables to use full math calculations for acceleration and feedrates.
@@ -43,7 +46,7 @@
 #
 # Save this file f.e. as /home/pi/klipper_config/ADVANCED_PAUSE.cfg to leave printer.cfg nice and clean
 # then use [include /home/pi/klipper_config/ADVANCED_PAUSE.cfg] in your printer.cfg
-# Don't forget to configure default values in [gcode_macro m600cfg] down below
+# Don't forget to configure default values in [gcode_macro cfg_m600] down below
 # 
 #
 # Usage in CURA Slicer:
@@ -117,7 +120,7 @@ recover_velocity: 50.0
 #-------------------------------------------------------------------------
 
 #####################
-[gcode_macro m600cfg]
+[gcode_macro cfg_m600]
 #####################
 
 # CONFIGURE YOUR VALUES INSIDE THIS GCODE_MACRO
@@ -229,44 +232,44 @@ gcode:
 
      #-# * * * THERE SHOULD BE NO NEED TO EDIT ANYTHING BELOW THIS POINT * * * #-#
 
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=default_temp VALUE={default_temp}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=cooldown VALUE={cooldown}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=fans_on VALUE={fans_on}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=x VALUE={x}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=y VALUE={y}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=park_feedrate VALUE={park_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=z VALUE={z}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=z_feedrate VALUE={z_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=zmin VALUE={zmin}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=park_retract_feedrate VALUE={park_retract_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=park_retract_length VALUE={park_retract_length}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=unload_purge_retract VALUE={unload_purge_retract}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=unload_purge_delay VALUE={unload_purge_delay}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=unload_purge_length VALUE={unload_purge_length}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=unload_purge_feedrate VALUE={unload_purge_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=unload_feedrate VALUE={unload_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=unload_accel VALUE={unload_accel}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=unload_length VALUE={unload_length}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=slow_load_feedrate VALUE={slow_load_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=slow_load_length VALUE={slow_load_length}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=fast_load_feedrate VALUE={fast_load_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=fast_load_accel VALUE={fast_load_accel}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=fast_load_length VALUE={fast_load_length}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=purge_feedrate VALUE={purge_feedrate}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=purge_length VALUE={purge_length}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=additional_purge VALUE={additional_purge}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=output VALUE={output}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=step_a1 VALUE={step_a1}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=step_b1 VALUE={step_b1}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=step_v1 VALUE={step_c1}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=step_d1 VALUE={step_d1}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=step_2 VALUE={step_2}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=step_3 VALUE={step_3}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=cancel VALUE={cancel}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=finish VALUE={finish}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=next VALUE={next}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=previous VALUE={previous}
-     SET_GCODE_VARIABLE MACRO=m600cfg VARIABLE=purgetext VALUE={purgetext}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=default_temp VALUE={default_temp}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=cooldown VALUE={cooldown}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=fans_on VALUE={fans_on}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=x VALUE={x}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=y VALUE={y}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=park_feedrate VALUE={park_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=z VALUE={z}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=z_feedrate VALUE={z_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=zmin VALUE={zmin}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=park_retract_feedrate VALUE={park_retract_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=park_retract_length VALUE={park_retract_length}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=unload_purge_retract VALUE={unload_purge_retract}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=unload_purge_delay VALUE={unload_purge_delay}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=unload_purge_length VALUE={unload_purge_length}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=unload_purge_feedrate VALUE={unload_purge_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=unload_feedrate VALUE={unload_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=unload_accel VALUE={unload_accel}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=unload_length VALUE={unload_length}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=slow_load_feedrate VALUE={slow_load_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=slow_load_length VALUE={slow_load_length}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=fast_load_feedrate VALUE={fast_load_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=fast_load_accel VALUE={fast_load_accel}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=fast_load_length VALUE={fast_load_length}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=purge_feedrate VALUE={purge_feedrate}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=purge_length VALUE={purge_length}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=additional_purge VALUE={additional_purge}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=output VALUE={output}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=step_a1 VALUE={step_a1}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=step_b1 VALUE={step_b1}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=step_v1 VALUE={step_c1}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=step_d1 VALUE={step_d1}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=step_2 VALUE={step_2}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=step_3 VALUE={step_3}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=cancel VALUE={cancel}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=finish VALUE={finish}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=next VALUE={next}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=previous VALUE={previous}
+     SET_GCODE_VARIABLE MACRO=cfg_m600 VARIABLE=purgetext VALUE={purgetext}
 
 
 #######################
@@ -287,11 +290,11 @@ gcode:
 
 	{% if NEWJOB == 6004 %}
 
-		M{printer["gcode_macro m600cfg"].output|int} Purging...
+		M{printer["gcode_macro cfg_m600"].output|int} Purging...
 		M83
     		G92 E0.0
-          G1 E{printer["gcode_macro m600cfg"].purge_length|int} F{printer["gcode_macro m600cfg"].purge_feedrate|int}
-          G1 E-{printer["gcode_macro m600cfg"].park_retract_length|int} F{printer["gcode_macro m600cfg"].park_retract_feedrate|int}
+          G1 E{printer["gcode_macro cfg_m600"].purge_length|int} F{printer["gcode_macro cfg_m600"].purge_feedrate|int}
+          G1 E-{printer["gcode_macro cfg_m600"].park_retract_length|int} F{printer["gcode_macro cfg_m600"].park_retract_feedrate|int}
           G92 E0.0
 
 		{% set NEWJOB=6005 %}
@@ -300,7 +303,7 @@ gcode:
 
 	{% if NEWJOB == 6003 %}
 
-          M{printer["gcode_macro m600cfg"].output|int} Resuming the print...
+          M{printer["gcode_macro cfg_m600"].output|int} Resuming the print...
 
           {% if printer["gcode_macro JOB_CENTER"].temperature==0 %}
 
@@ -323,15 +326,15 @@ gcode:
 
 		{% if NEWJOB==6002 %}
 
-			M{printer["gcode_macro m600cfg"].output|int} Loading Filament...
+			M{printer["gcode_macro cfg_m600"].output|int} Loading Filament...
 			M701
 
 		{% endif %}
 
-		RESPOND TYPE=command MSG="action:prompt_begin {printer["gcode_macro m600cfg"].step_3}"
-		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro m600cfg"].finish}"
-		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro m600cfg"].previous}"
-		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro m600cfg"].purgetext} {printer["gcode_macro m600cfg"].additional_purge|int}mm"
+		RESPOND TYPE=command MSG="action:prompt_begin {printer["gcode_macro cfg_m600"].step_3}"
+		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro cfg_m600"].finish}"
+		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro cfg_m600"].previous}"
+		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro cfg_m600"].purgetext} {printer["gcode_macro cfg_m600"].additional_purge|int}mm"
 		RESPOND TYPE=command MSG="action:prompt_show"
 
           {% set myjob=6003 %}
@@ -341,10 +344,10 @@ gcode:
 	{% if NEWJOB == 6001 %}
 
 		LOW_TEMP_CHECK T={printer["gcode_macro JOB_CENTER"].temperature}
-		M{printer["gcode_macro m600cfg"].output|int} Unloading Filament...
+		M{printer["gcode_macro cfg_m600"].output|int} Unloading Filament...
 		M702
-		RESPOND TYPE=command MSG="action:prompt_begin {printer["gcode_macro m600cfg"].step_2}"
-          RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro m600cfg"].next}"
+		RESPOND TYPE=command MSG="action:prompt_begin {printer["gcode_macro cfg_m600"].step_2}"
+          RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro cfg_m600"].next}"
 		RESPOND TYPE=command MSG="action:prompt_show"
 
           {% set myjob=6002 %}
@@ -353,7 +356,7 @@ gcode:
 
 	{% if NEWJOB == 5999 %}
 
-          M{printer["gcode_macro m600cfg"].output|int} M600 Cancelled, Resuming the Print.
+          M{printer["gcode_macro cfg_m600"].output|int} M600 Cancelled, Resuming the Print.
 
           {% if printer["gcode_macro JOB_CENTER"].temperature != 0 %}
 
@@ -372,13 +375,13 @@ gcode:
 
 		PAUSE
 		M125
-		{% set cool=printer["gcode_macro m600cfg"].cooldown|int %}
-          {% set fans=printer["gcode_macro m600cfg"].fans_on|int %}
-		{% set mystep=[printer["gcode_macro m600cfg"].step_a1,printer["gcode_macro m600cfg"].step_b1,printer["gcode_macro m600cfg"].step_d1]|join() %}
+		{% set cool=printer["gcode_macro cfg_m600"].cooldown|int %}
+          {% set fans=printer["gcode_macro cfg_m600"].fans_on|int %}
+		{% set mystep=[printer["gcode_macro cfg_m600"].step_a1,printer["gcode_macro cfg_m600"].step_b1,printer["gcode_macro cfg_m600"].step_d1]|join() %}
 		{% if cool != 0 %}
 
 			M104 S0
-			{% set mystep=[printer["gcode_macro m600cfg"].step_a1,printer["gcode_macro m600cfg"].step_c1,printer["gcode_macro m600cfg"].step_d1]|join() %}
+			{% set mystep=[printer["gcode_macro cfg_m600"].step_a1,printer["gcode_macro cfg_m600"].step_c1,printer["gcode_macro cfg_m600"].step_d1]|join() %}
 
 		{% endif %}
           {% if fans != 0 %}
@@ -390,8 +393,8 @@ gcode:
 		SET_IDLE_TIMEOUT TIMEOUT=45
 		
 		RESPOND TYPE=command MSG="action:prompt_begin {mystep}"
-		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro m600cfg"].next}"
-		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro m600cfg"].cancel}"
+		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro cfg_m600"].next}"
+		RESPOND TYPE=command MSG="action:prompt_choice {printer["gcode_macro cfg_m600"].cancel}"
 		RESPOND TYPE=command MSG="action:prompt_show"
 
           {% set myjob=6001 %}
@@ -416,7 +419,7 @@ gcode:
 
                     {% if params.T|int>printer.configfile.config.extruder.max_temp|int %}
 
-                         {% set TMP=printer["gcode_macro m600cfg"].default_temp|int %}
+                         {% set TMP=printer["gcode_macro cfg_m600"].default_temp|int %}
 
                     {% endif %}
 
@@ -424,7 +427,7 @@ gcode:
 
                {% if TMP|int==0 %}
 
-                    {% set TMP=printer["gcode_macro m600cfg"].default_temp|int %}
+                    {% set TMP=printer["gcode_macro cfg_m600"].default_temp|int %}
 
                {% endif %}
 
@@ -432,7 +435,7 @@ gcode:
 
      {% else %}
 
-          {% set TMP=printer["gcode_macro m600cfg"].default_temp|int %}
+          {% set TMP=printer["gcode_macro cfg_m600"].default_temp|int %}
 
           {% if printer["gcode_macro JOB_CENTER"].temperature|int > 0 %}
 
@@ -446,7 +449,7 @@ gcode:
 
           {% if TMP|int<printer.configfile.config.extruder.min_extrude_temp|int %}
 
-               {% set TMP=printer["gcode_macro m600cfg"].default_temp %}
+               {% set TMP=printer["gcode_macro cfg_m600"].default_temp %}
 
           {% endif %}
 
@@ -458,7 +461,7 @@ gcode:
 
           {% else %}
 
-               {% set TMP=printer["gcode_macro m600cfg"].default_temp %}
+               {% set TMP=printer["gcode_macro cfg_m600"].default_temp %}
 
           {% endif %}
 
@@ -466,12 +469,12 @@ gcode:
 
      {% if printer.extruder.temperature|int > TMP|int %}
 
-               M{printer["gcode_macro m600cfg"].output|int} Temperature set to {TMP}.
+               M{printer["gcode_macro cfg_m600"].output|int} Temperature set to {TMP}.
                M104 S{TMP}
 
      {% else %}
 
-               M{printer["gcode_macro m600cfg"].output|int} Heating to {TMP}.
+               M{printer["gcode_macro cfg_m600"].output|int} Heating to {TMP}.
                M109 S{TMP}
 
      {% endif %}
@@ -483,13 +486,13 @@ gcode:
 
 gcode:
 
-	M{printer["gcode_macro m600cfg"].output|int} Moving hotend to {printer["gcode_macro m600cfg"].x|int}, {printer["gcode_macro m600cfg"].y|int}, {printer["gcode_macro m600cfg"].z|int} ({printer["gcode_macro m600cfg"].zmin|int})
+	M{printer["gcode_macro cfg_m600"].output|int} Moving hotend to {printer["gcode_macro cfg_m600"].x|int}, {printer["gcode_macro cfg_m600"].y|int}, {printer["gcode_macro cfg_m600"].z|int} ({printer["gcode_macro cfg_m600"].zmin|int})
 	SET_GCODE_VARIABLE MACRO=JOB_CENTER VARIABLE=temperature VALUE={printer.extruder.target}
 
 	{% if printer.toolhead.homed_axes != "xyz" %}
 	# If Axes Not Homed
 
-		M{printer["gcode_macro m600cfg"].output|int} Homing the printer...
+		M{printer["gcode_macro cfg_m600"].output|int} Homing the printer...
 		G28
           G0 Z5.0 F600.0
 
@@ -501,26 +504,26 @@ gcode:
 	{% if printer.extruder.target != 0 %}
 
 	     LOW_TEMP_CHECK
-          G1 {printer["gcode_macro m600cfg"].park_retract_length|int} F{printer["gcode_macro m600cfg"].park_retract_feedrate|int}
+          G1 {printer["gcode_macro cfg_m600"].park_retract_length|int} F{printer["gcode_macro cfg_m600"].park_retract_feedrate|int}
 
 	{% endif %}
 
-	{% if printer.toolhead.position.z|float + printer["gcode_macro m600cfg"].z|float < printer.configfile.config["stepper_z"]["position_max"]|float %}
+	{% if printer.toolhead.position.z|float + printer["gcode_macro cfg_m600"].z|float < printer.configfile.config["stepper_z"]["position_max"]|float %}
 
-		{% if printer.toolhead.position.z < printer["gcode_macro m600cfg"].zmin|int %}
+		{% if printer.toolhead.position.z < printer["gcode_macro cfg_m600"].zmin|int %}
 
-        	  G1 Z{printer["gcode_macro m600cfg"].zmin|float + printer.toolhead.position.z|float}
+        	  G1 Z{printer["gcode_macro cfg_m600"].zmin|float + printer.toolhead.position.z|float}
 
 		{% else %}
 
-          	G1 Z{printer["gcode_macro m600cfg"].z|int}
+          	G1 Z{printer["gcode_macro cfg_m600"].z|int}
 
      	{% endif %}
 
 	{% endif %}
 
 	G90
-	G1 X{printer["gcode_macro m600cfg"].x|int} Y{printer["gcode_macro m600cfg"].y|int} F{printer["gcode_macro m600cfg"].park_feedrate|int}
+	G1 X{printer["gcode_macro cfg_m600"].x|int} Y{printer["gcode_macro cfg_m600"].y|int} F{printer["gcode_macro cfg_m600"].park_feedrate|int}
 
 
 ##################
@@ -541,11 +544,11 @@ gcode:
      M83
      G92 E0.0
      LOW_TEMP_CHECK
-     G1 E{printer["gcode_macro m600cfg"].slow_load_length|int} F{printer["gcode_macro m600cfg"].slow_load_feedrate|int}
+     G1 E{printer["gcode_macro cfg_m600"].slow_load_length|int} F{printer["gcode_macro cfg_m600"].slow_load_feedrate|int}
      G92 E0.0
-     G1 E{printer["gcode_macro m600cfg"].fast_load_length|int} F{printer["gcode_macro m600cfg"].fast_load_feedrate|int}
+     G1 E{printer["gcode_macro cfg_m600"].fast_load_length|int} F{printer["gcode_macro cfg_m600"].fast_load_feedrate|int}
      G92 E0.0
-     G1 E{printer["gcode_macro m600cfg"].purge_length|int} F{printer["gcode_macro m600cfg"].purge_feedrate|int}
+     G1 E{printer["gcode_macro cfg_m600"].purge_length|int} F{printer["gcode_macro cfg_m600"].purge_feedrate|int}
      G92 E0.0
      M82
 
@@ -561,16 +564,16 @@ gcode:
 #	{% if printer.toolhead.homed_axes != "z" %}
 	     # If Z-Axis Not Homed
 #          SET_KINEMATIC_POSITION Z=0    
-#          G0 Z{printer["gcode_macro m600cfg"].z|int} F{printer["gcode_macro m600cfg"].z_feedrate|int}
+#          G0 Z{printer["gcode_macro cfg_m600"].z|int} F{printer["gcode_macro cfg_m600"].z_feedrate|int}
 #     {% else %}
 #          # If Z-Axis Homed
-#          G0 Z{printer["gcode_macro m600cfg"].z|int} F{printer["gcode_macro m600cfg"].z_feedrate|int}
+#          G0 Z{printer["gcode_macro cfg_m600"].z|int} F{printer["gcode_macro cfg_m600"].z_feedrate|int}
 #     {% endif %}
      M125
-     G1 E-{printer["gcode_macro m600cfg"].unload_purge_retract|int} F{printer["gcode_macro m600cfg"].unload_purge_feedrate|int}
-     G4 P{printer["gcode_macro m600cfg"].unload_purge_delay|int}
-     G1 E{printer["gcode_macro m600cfg"].unload_purge_length|int} F{printer["gcode_macro m600cfg"].unload_purge_feedrate|int}
-     G1 E-{printer["gcode_macro m600cfg"].unload_length|int} F{printer["gcode_macro m600cfg"].unload_feedrate|int}
+     G1 E-{printer["gcode_macro cfg_m600"].unload_purge_retract|int} F{printer["gcode_macro cfg_m600"].unload_purge_feedrate|int}
+     G4 P{printer["gcode_macro cfg_m600"].unload_purge_delay|int}
+     G1 E{printer["gcode_macro cfg_m600"].unload_purge_length|int} F{printer["gcode_macro cfg_m600"].unload_purge_feedrate|int}
+     G1 E-{printer["gcode_macro cfg_m600"].unload_length|int} F{printer["gcode_macro cfg_m600"].unload_feedrate|int}
      G90
 
 

--- a/ADVANCED_PAUSE.cfg
+++ b/ADVANCED_PAUSE.cfg
@@ -8,7 +8,10 @@
 #  NO RESPONSE TAKEN FOR ANY DAMAGE CAUSED BY MOM ;)
 #------------------------------------------------------
 #
-# 01/14/2025 v9.4.2
+# 01/14/2025 v0.4.3
+# Fixed UndefinedError for TMP variable in LOW_TEMP_CHECK when macro is called without paramaters. Issue was introduced in v0.3.5 commit 8cf8e9a.
+#
+# 01/14/2025 v0.4.2
 # Changed gcode macro name from 'm600cfg' to 'cfg_m600' because of naming convention change. Macro's not conforming to this convention cannot be registered in Klipper.
 #
 # 04/30/2022 v0.4.1
@@ -431,39 +434,39 @@ gcode:
 
                {% endif %}
 
-          {% endif %}
+         {% else %}
 
-     {% else %}
+              {% set TMP=printer["gcode_macro cfg_m600"].default_temp|int %}
 
-          {% set TMP=printer["gcode_macro cfg_m600"].default_temp|int %}
+              {% if printer["gcode_macro JOB_CENTER"].temperature|int > 0 %}
 
-          {% if printer["gcode_macro JOB_CENTER"].temperature|int > 0 %}
+                   {% set TMP=printer["gcode_macro JOB_CENTER"].temperature %}
 
-               {% set TMP=printer["gcode_macro JOB_CENTER"].temperature %}
+              {% endif %}
 
-          {% endif %}
+         {% endif %}
 
-     {% endif %}
+         {% if printer.configfile.config.extruder.min_extrude_temp is defined %}
 
-     {% if printer.configfile.config.extruder.min_extrude_temp is defined %}
-
-          {% if TMP|int<printer.configfile.config.extruder.min_extrude_temp|int %}
+             {% if TMP|int<printer.configfile.config.extruder.min_extrude_temp|int %}
 
                {% set TMP=printer["gcode_macro cfg_m600"].default_temp %}
 
-          {% endif %}
+             {% endif %}
+          
+         {% endif %}
 
      {% else %}
+        
+         {% if params.T is defined %}
 
-          {% if params.T is defined %}
+             {% set TMP=params.T|int %}
 
-               {% set TMP=params.T|int %}
+         {% else %}
 
-          {% else %}
+             {% set TMP=printer["gcode_macro cfg_m600"].default_temp %}
 
-               {% set TMP=printer["gcode_macro cfg_m600"].default_temp %}
-
-          {% endif %}
+         {% endif %}
 
      {% endif %}
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Install as you would normally a Klipper Macro file.
 
+01/14/2025 v0.4.3
+Fixed UndefinedError for TMP variable in LOW_TEMP_CHECK when macro is called without paramaters. Issue was introduced in v0.3.5 commit 8cf8e9a.
+
+01/14/2025 v0.4.2
+Changed gcode macro name from 'm600cfg' to 'cfg_m600' because of naming convention change. Macro's not conforming to this convention cannot be registered in Klipper.
+
 04/30/2022 v0.4.1
 Corrected bugs with M125 and raising the zmin twice.
 


### PR DESCRIPTION
Hello RushHour2k5,

I was trying to install the Klipper_MrsIncredible macro and ran into three issues:

1. [Klipper macro naming convention](https://www.klipper3d.org/Command_Templates.html#g-code-macro-naming) recently changed as part of [gcode: Improve handling of extended g-code commands with '*;#' characters](https://github.com/Klipper3d/klipper/pull/6749)
2. UndefinedError in LOW_TEMP_CHECK
3. The macros are optimised for OctoPrint 😅

So issue 3 is a "me" issue. I just went in like a headless chicken and didn't care the macros were optimised for OctoPrint and I had the bad luck that the Action Command Prompt of OctoPrint is different than that of Mainsail. 

For issues 1 and 2 I made changes in my fork. Maybe you would like to add these changes to your repository? I could validate that my edit for the macro naming convention worked because the macro could be registered. I could validate my edit for the UndefinedError in LOW_TEMP_CHECK worked because I could call that macro from the console. (I could not check if all worked together because of issue number 3 and I'm not planning to switch over to OctoPrint just to check.)

Kind regards!

Koen Mulder